### PR TITLE
Add URL pattern logging

### DIFF
--- a/src/Processors/UrlPatternProcessor.php
+++ b/src/Processors/UrlPatternProcessor.php
@@ -17,7 +17,7 @@ class UrlPatternProcessor implements ProcessorInterface
 
         // add the patterned url to the log context
         if (filled($uri)) {
-            $records['extra']['url_pattern'] = optional(app('router')->getCurrentRoute())->uri();
+            $records['extra']['url_pattern'] = $uri;
         }
 
         return $records;

--- a/src/Processors/UrlPatternProcessor.php
+++ b/src/Processors/UrlPatternProcessor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HealthEngine\LaravelLogging\Processors;
+
+use Monolog\Processor\ProcessorInterface;
+
+class UrlPatternProcessor implements ProcessorInterface
+{
+    /**
+     * @param  array $records
+     * @return array
+     */
+    public function __invoke(array $records)
+    {
+        // get the current request, taking care that this might be in a CLI context
+        $uri = optional(request()->route())->uri();
+
+        // add the patterned url to the log context
+        if (filled($uri)) {
+            $records['extra']['url_pattern'] = optional(app('router')->getCurrentRoute())->uri();
+        }
+
+        return $records;
+    }
+}

--- a/src/Taps/ProcessorTap.php
+++ b/src/Taps/ProcessorTap.php
@@ -3,6 +3,7 @@
 namespace HealthEngine\LaravelLogging\Taps;
 
 use HealthEngine\LaravelLogging\Processors\BuildTagProcessor;
+use HealthEngine\LaravelLogging\Processors\UrlPatternProcessor;
 use Monolog\Processor\MemoryPeakUsageProcessor;
 use Monolog\Processor\MemoryUsageProcessor;
 use Monolog\Processor\UidProcessor;
@@ -23,6 +24,7 @@ class ProcessorTap
             ->pushProcessor(new MemoryPeakUsageProcessor(true, false))
             ->pushProcessor(new MemoryUsageProcessor(true, false))
             ->pushProcessor(new UidProcessor())
+            ->pushProcessor(new UrlPatternProcessor())
             ->pushProcessor(
                 new WebProcessor(
                     null,

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -79,12 +79,16 @@ class LoggingTest extends TestCase
         $logger->pushProcessor(new UrlPatternProcessor());
         Log::swap($logger);
 
-        // log something
-        Log::info('testing');
+        // register a route that will log something
+        $this->app->get('router')->get('api/{binding}', function ($binding) {
+            Log::info('testing');
+        });
+        // make the request
+        $this->get('api/bound');
 
         // then assert that the url is included
         $records = $handler->getRecords();
-        $this->assertEquals('', $records[0]['extra']['url_pattern']);
+        $this->assertEquals('api/{binding}', $records[0]['extra']['url_pattern']);
     }
 
     public function testUrlPatternNotIncluded()

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -82,7 +82,7 @@ class LoggingTest extends TestCase
         // log something
         Log::info('testing');
 
-        // then assert that the build tag is present
+        // then assert that the url is included
         $records = $handler->getRecords();
         $this->assertEquals('', $records[0]['extra']['url_pattern']);
     }
@@ -98,7 +98,7 @@ class LoggingTest extends TestCase
         // log something
         Log::info('testing');
 
-        // then assert that the build tag is present
+        // then assert that the url is not included
         $records = $handler->getRecords();
         $this->assertArrayNotHasKey('url_pattern', $records[0]['extra']);
     }


### PR DESCRIPTION
This is useful for monitoring the general endpoints without using route parameters like resource ID's etc. It allows better monitoring on a per endpoint/controller method.

For example, it would help with this: https://www.honeycomb.io/blog/tell-me-more-nginx/