### PR TITLE
Update web processor logging context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v4.0.0]
+## [v4.0.2] - 2023-08-08
+
+### Added
+
+- Added new logging context `extra.forwarded_for` which uses the value of `$_SERVER['HTTP_X_FORWARDED_FOR']`.
+
+### Changed
+
+- Changed logging context `extra.ip` to use value of `$_SERVER['REMOTE_ADDR']` instead of
+  `$_SERVER['HTTP_X_FORWARDED_FOR']`.
+
+## [v4.0.1] - 2023-08-03
+
+### Added
+
+- Added new logging context `extra.user_agent` which uses the value of `$_SERVER['HTTP_USER_AGENT']`.
+
+## [v4.0.0] - 2023-03-14
 
 ### Added
 
@@ -19,6 +36,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for Laravel 7, 8, and 9.
 - Removed support for Monolog 2.
 - Removed support for PHP 7.4, and 8.0.
+
+## [v3.0.4] - 2023-08-08
+
+### Added
+
+- Added new logging context `extra.forwarded_for` which uses the value of `$_SERVER['HTTP_X_FORWARDED_FOR']`.
+
+### Changed
+
+- Changed logging context `extra.ip` to use value of `$_SERVER['REMOTE_ADDR']` instead of
+  `$_SERVER['HTTP_X_FORWARDED_FOR']`.
+
+## [v3.0.3] - 2023-08-03
+
+### Added
+
+- Added new logging context `extra.user_agent` which uses the value of `$_SERVER['HTTP_USER_AGENT']`.
 
 ## [v3.0.2]
 
@@ -65,3 +99,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for versions `~5.7` and `^6.0` of `illuminate/support`.
 - Removed testing against PHP 7.3 in Travis CI.
 - Removed support for versions `^7.5` and `^8.0` of `phpunit/phpunit`.
+
+[unreleased]: https://github.com/HealthEngineAU/laravel-logging/compare/v4.0.2...HEAD
+[v4.0.2]: https://github.com/HealthEngineAU/laravel-logging/compare/v4.0.1...v4.0.2
+[v4.0.1]: https://github.com/HealthEngineAU/laravel-logging/compare/v4.0.0...v4.0.1
+[v4.0.0]: https://github.com/HealthEngineAU/laravel-logging/compare/v3.0.4...v4.0.0
+[v3.0.4]: https://github.com/HealthEngineAU/laravel-logging/compare/v3.0.3...v3.0.4
+[v3.0.3]: https://github.com/HealthEngineAU/laravel-logging/compare/v3.0.2...v3.0.3
+[v3.0.2]: https://github.com/HealthEngineAU/laravel-logging/compare/v3.0.1...v3.0.2
+[v3.0.1]: https://github.com/HealthEngineAU/laravel-logging/compare/v3.0.0...v3.0.1
+[v3.0.0]: https://github.com/HealthEngineAU/laravel-logging/compare/v2.0.4....v3.0.0

--- a/src/Taps/ProcessorTap.php
+++ b/src/Taps/ProcessorTap.php
@@ -32,8 +32,9 @@ class ProcessorTap
                 new WebProcessor(
                     null,
                     [
+                        'forwarded_for' => 'HTTP_X_FORWARDED_FOR',
                         'http_method' => 'REQUEST_METHOD',
-                        'ip' => 'HTTP_X_FORWARDED_FOR',
+                        'ip' => 'REMOTE_ADDR',
                         'referrer' => 'HTTP_REFERER',
                         'server' => 'SERVER_NAME',
                         'unique_id' => 'HTTP_X_AMZN_TRACE_ID',

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -136,6 +136,25 @@ class LoggingTest extends TestCase
 
     public function testProcessorTap()
     {
+        $expectedForwardedFor = '192.168.1.1, 10.0.0.1';
+        $expectedHttpMethod = 'GET';
+        $expectedIp = '192.168.1.1';
+        $expectedReferrer = 'https://duckduckgo.com/';
+        $expectedServer = 'duckduckgo.com';
+        $expectedUniqueId = '03ef5820-228c-4344-b43a-c9c8bc36e3bf';
+        $expectedUrl = '/home';
+        $expectedUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0'
+            . ' Safari/537.36';
+
+        $_SERVER['HTTP_REFERER'] = $expectedReferrer;
+        $_SERVER['HTTP_USER_AGENT'] = $expectedUserAgent;
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = $expectedForwardedFor;
+        $_SERVER['HTTP_X_AMZN_TRACE_ID'] = $expectedUniqueId;
+        $_SERVER['REMOTE_ADDR'] = $expectedIp;
+        $_SERVER['REQUEST_METHOD'] = $expectedHttpMethod;
+        $_SERVER['REQUEST_URI'] = $expectedUrl;
+        $_SERVER['SERVER_NAME'] = $expectedServer;
+
         // configure a test logger
         $handler = new TestHandler();
         $logger = new Logger('testing', [$handler]);
@@ -148,9 +167,26 @@ class LoggingTest extends TestCase
 
         // assert the log value contains the extra keys
         $record = $handler->getRecords()[0]['extra'];
+
+        $this->assertArrayHasKey('forwarded_for', $record);
+        $this->assertEquals($record['forwarded_for'], $expectedForwardedFor);
+        $this->assertArrayHasKey('http_method', $record);
+        $this->assertEquals($record['http_method'], $expectedHttpMethod);
+        $this->assertArrayHasKey('ip', $record);
+        $this->assertEquals($record['ip'], $expectedIp);
         $this->assertArrayHasKey('memory_peak_usage', $record);
         $this->assertArrayHasKey('memory_usage', $record);
+        $this->assertArrayHasKey('referrer', $record);
+        $this->assertEquals($record['referrer'], $expectedReferrer);
+        $this->assertArrayHasKey('server', $record);
+        $this->assertEquals($record['server'], $expectedServer);
         $this->assertArrayHasKey('uid', $record);
+        $this->assertArrayHasKey('unique_id', $record);
+        $this->assertEquals($record['unique_id'], $expectedUniqueId);
+        $this->assertArrayHasKey('url', $record);
+        $this->assertEquals($record['url'], $expectedUrl);
+        $this->assertArrayHasKey('user_agent', $record);
+        $this->assertEquals($record['user_agent'], $expectedUserAgent);
     }
 
     public function testLogstashSingleChannel()


### PR DESCRIPTION
- Added new logging context `extra.forwarded_for` which uses the value of `$_SERVER['HTTP_X_FORWARDED_FOR']`.
- Changed logging context `extra.ip` to use value of `$_SERVER['REMOTE_ADDR']` instead of `$_SERVER['HTTP_X_FORWARDED_FOR']`.