### PR TITLE
HEAL-5576 Add AWS trace header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v4.1.0] - 2024-11-29
+
+### Added
+
+- AWS trace ID header added to monolog record `X-Amzn-Trace-Id`
+
+### Removed
+
+- Removed `unique_id` log field
+
 ## [v4.0.4] - 2024-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- AWS trace ID header added to monolog record `X-Amzn-Trace-Id`
+- AWS trace ID header added to top-level key in monolog record `X-Amzn-Trace-Id`
 
 ### Removed
 
-- Removed `unique_id` log field
+- Removed `extra.unique_id` log field
 
 ## [v4.0.4] - 2024-08-29
 
@@ -120,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed testing against PHP 7.3 in Travis CI.
 - Removed support for versions `^7.5` and `^8.0` of `phpunit/phpunit`.
 
+[v4.1.0]: https://github.com/HealthengineAU/laravel-logging/compare/v4.0.4...v4.1.0
 [v4.0.4]: https://github.com/HealthengineAU/laravel-logging/compare/v4.0.3...v4.0.4
 [v4.0.3]: https://github.com/HealthengineAU/laravel-logging/compare/v4.0.2...v4.0.3
 [v4.0.2]: https://github.com/HealthengineAU/laravel-logging/compare/v4.0.1...v4.0.2

--- a/src/Formatters/LogstashFormatter.php
+++ b/src/Formatters/LogstashFormatter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Healthengine\LaravelLogging\Formatters;
+
+use Monolog\Formatter\LogstashFormatter as BaseLogstashFormatter;
+use Monolog\LogRecord;
+
+class LogstashFormatter extends BaseLogstashFormatter
+{
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): string
+    {
+        $recordData = parent::normalizeRecord($record);
+
+        $message = [
+            '@timestamp' => $recordData['datetime'],
+            '@version' => 1,
+            'host' => $this->systemName,
+        ];
+        if (isset($recordData['message'])) {
+            $message['message'] = $recordData['message'];
+        }
+        if (isset($recordData['channel'])) {
+            $message['type'] = $recordData['channel'];
+            $message['channel'] = $recordData['channel'];
+        }
+        if (isset($recordData['level_name'])) {
+            $message['level'] = $recordData['level_name'];
+        }
+        if (isset($recordData['level'])) {
+            $message['monolog_level'] = $recordData['level'];
+        }
+        if ('' !== $this->applicationName) {
+            $message['type'] = $this->applicationName;
+        }
+        if (\count($recordData['extra']) > 0) {
+            $message[$this->extraKey] = $recordData['extra'];
+        }
+        if (\count($recordData['context']) > 0) {
+            $message[$this->contextKey] = $recordData['context'];
+        }
+
+        $this->injectOtherData($message);
+
+        return $this->toJson($message) . "\n";
+    }
+
+    public function injectOtherData(array &$message)
+    {
+        $message['X-Amzn-Trace-Id'] = $_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? '';
+    }
+}

--- a/src/Taps/LogstashTap.php
+++ b/src/Taps/LogstashTap.php
@@ -2,7 +2,7 @@
 
 namespace Healthengine\LaravelLogging\Taps;
 
-use Monolog\Formatter\LogstashFormatter;
+use Healthengine\LaravelLogging\Formatters\LogstashFormatter;
 
 class LogstashTap
 {

--- a/src/Taps/ProcessorTap.php
+++ b/src/Taps/ProcessorTap.php
@@ -4,7 +4,7 @@ namespace Healthengine\LaravelLogging\Taps;
 
 use Healthengine\LaravelLogging\Processors\BuildTagProcessor;
 use Healthengine\LaravelLogging\Processors\UrlPatternProcessor;
-use Monolog\Logger as MonoLogger;
+use Monolog\Level;
 use Monolog\Processor\IntrospectionProcessor;
 use Monolog\Processor\MemoryPeakUsageProcessor;
 use Monolog\Processor\MemoryUsageProcessor;
@@ -27,7 +27,7 @@ class ProcessorTap
             ->pushProcessor(new MemoryUsageProcessor(true, false))
             ->pushProcessor(new UidProcessor())
             ->pushProcessor(new UrlPatternProcessor())
-            ->pushProcessor(new IntrospectionProcessor(MonoLogger::DEBUG, ['Illuminate\\']))
+            ->pushProcessor(new IntrospectionProcessor(Level::Debug, ['Illuminate\\']))
             ->pushProcessor(
                 new WebProcessor(
                     null,
@@ -37,10 +37,10 @@ class ProcessorTap
                         'ip' => 'REMOTE_ADDR',
                         'referrer' => 'HTTP_REFERER',
                         'server' => 'SERVER_NAME',
-                        'unique_id' => 'HTTP_X_AMZN_TRACE_ID',
                         'url' => 'REQUEST_URI',
                         'user_agent'  => 'HTTP_USER_AGENT',
-                    ])
+                    ],
+                ),
             );
     }
 }

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -143,7 +143,6 @@ class LoggingTest extends TestCase
         $expectedIp = '192.168.1.1';
         $expectedReferrer = 'https://duckduckgo.com/';
         $expectedServer = 'duckduckgo.com';
-        $expectedUniqueId = '03ef5820-228c-4344-b43a-c9c8bc36e3bf';
         $expectedUrl = '/home';
         $expectedUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0'
             . ' Safari/537.36';
@@ -151,7 +150,6 @@ class LoggingTest extends TestCase
         $_SERVER['HTTP_REFERER'] = $expectedReferrer;
         $_SERVER['HTTP_USER_AGENT'] = $expectedUserAgent;
         $_SERVER['HTTP_X_FORWARDED_FOR'] = $expectedForwardedFor;
-        $_SERVER['HTTP_X_AMZN_TRACE_ID'] = $expectedUniqueId;
         $_SERVER['REMOTE_ADDR'] = $expectedIp;
         $_SERVER['REQUEST_METHOD'] = $expectedHttpMethod;
         $_SERVER['REQUEST_URI'] = $expectedUrl;
@@ -183,8 +181,6 @@ class LoggingTest extends TestCase
         $this->assertArrayHasKey('server', $record);
         $this->assertEquals($record['server'], $expectedServer);
         $this->assertArrayHasKey('uid', $record);
-        $this->assertArrayHasKey('unique_id', $record);
-        $this->assertEquals($record['unique_id'], $expectedUniqueId);
         $this->assertArrayHasKey('url', $record);
         $this->assertEquals($record['url'], $expectedUrl);
         $this->assertArrayHasKey('user_agent', $record);

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -18,6 +18,7 @@ use Monolog\Processor\UidProcessor;
 use Orchestra\Testbench\TestCase;
 
 /**
+ * @covers \Healthengine\LaravelLogging\Formatters\LogstashFormatter
  * @covers \Healthengine\LaravelLogging\Processors\BuildTagProcessor
  * @covers \Healthengine\LaravelLogging\Processors\UrlPatternProcessor
  * @covers \Healthengine\LaravelLogging\Taps\LogstashTap


### PR DESCRIPTION
Update the log config to put the AWS trace header in the same place as other services. This will allow better filtering for related records in kibana.
